### PR TITLE
[FEAT] QWEN 파이프라인 틀 설정

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+torch
+transformers
+sentence-transformers
+accelerate

--- a/src/demo_run.py
+++ b/src/demo_run.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""데모 러너: 페르소나 인덱스로 personas.json에서 페르소나 정보를 조회하여 실행
+
+사용 예:
+  python3 src/demo_run.py             # 기본값으로 실행 (Luxury_Lover, 설화수, 자음생크림)
+  python3 src/demo_run.py --persona_idx 1 --brand SK-II  # 다른 페르소나/브랜드
+  python3 src/demo_run.py --use_local_model  # 로컬 Qwen 모델로 생성
+"""
+import subprocess
+import os
+import sys
+import json
+import argparse
+
+BASE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GEN = os.path.join(BASE, 'src', 'generate_marketing.py')
+PERSONAS_JSON = os.path.join(BASE, 'data', 'personas.json')
+DEMO_PERSONAS = os.path.join('data', 'demo_personas.json')
+DEMO_PRODUCTS = os.path.join('data', 'demo_products.json')
+
+
+def load_personas():
+    """personas.json 로드"""
+    with open(PERSONAS_JSON, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def get_persona_name(persona_idx):
+    """페르소나 인덱스로 페르소나 이름 조회"""
+    personas = load_personas()
+    if 0 <= persona_idx < len(personas):
+        return personas[persona_idx].get('name', f'Persona_{persona_idx}')
+    return f'Persona_{persona_idx}'
+
+
+def build_cmd(use_real: bool, persona_idx: int, brand: str, product: str, top_k: int, use_local_model: bool = False, model_name: str = None):
+    cmd = [sys.executable, GEN,
+           '--persona', str(persona_idx),
+           '--brand', brand,
+           '--product', product,
+           '--top_k', str(top_k)]
+    if not use_real:
+        cmd += ['--personas_path', DEMO_PERSONAS, '--products_path', DEMO_PRODUCTS]
+    if use_local_model:
+        cmd.append('--use_local_model')
+        if model_name:
+            cmd += ['--model_name', model_name]
+    return cmd
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--use_real', action='store_true', default=True, help='기본 데이터(`data/*.json`) 사용 (기본값: True)')
+    parser.add_argument('--persona_idx', type=int, default=0, help='페르소나 인덱스 (기본값: 0 = Luxury_Lover)')
+    parser.add_argument('--brand', default='설화수', help='브랜드명 (부분일치 허용, 기본값: 설화수)')
+    parser.add_argument('--product', default='자음생크림 리치 단품세트 50ml', help='제품명(부분일치 허용, 기본값: 자음생크림 리치)')
+    parser.add_argument('--top_k', type=int, default=3, help='Top-K (기본값: 3)')
+    parser.add_argument('--use_local_model', action='store_true', help='로컬 Qwen 모델로 마케팅 초안 생성')
+    parser.add_argument('--model_name', default='Qwen/Qwen2.5-1.5B-Instruct', help='로컬 모델 ID')
+    args = parser.parse_args()
+
+    # 페르소나 인덱스로 페르소나 이름 조회
+    persona_name = get_persona_name(args.persona_idx)
+    print(f"[Demo Runner]")
+    print(f"  페르소나: {args.persona_idx} ({persona_name})")
+    print(f"  브랜드: {args.brand}")
+    print(f"  제품: {args.product}")
+    print(f"  Top-K: {args.top_k}")
+    if args.use_local_model:
+        print(f"  모델: {args.model_name} (로컬)")
+    print()
+
+    cmd = build_cmd(args.use_real, args.persona_idx, args.brand, args.product, args.top_k, 
+                    args.use_local_model, args.model_name if args.use_local_model else None)
+    subprocess.run(cmd, check=True)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/src/generate_marketing.py
+++ b/src/generate_marketing.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""
+Persona-Product RAG 및 로컬 Qwen 모델 기반 마케팅 초안 생성기
+
+사용법:
+  python3 src/generate_marketing.py --persona 0 --brand 설화수 --product "자음생크림 리치 단품세트"
+  python3 src/generate_marketing.py --persona 0 --brand 설화수 --product "자음생크림 리치 단품세트" --use_local_model
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+sys.path.insert(0, os.path.dirname(__file__))
+from rag_utils import vectorize_texts, cosine, extract_candidate_texts, extract_highlight_snippet, build_persona_query
+
+
+def load_json(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def find_persona(personas, persona_input):
+    # persona_input can be index or name
+    try:
+        idx = int(persona_input)
+        return personas[idx]
+    except Exception:
+        # lookup by name
+        for p in personas:
+            if p.get('name', '').lower() == persona_input.lower():
+                return p
+    raise ValueError('페르소나를 찾을 수 없습니다: %s' % persona_input)
+
+
+def find_product(products, brand, product_name):
+    brand_l = (brand or '').strip().lower()
+    name_l = (product_name or '').strip().lower()
+    # prefer exact brand + name match, otherwise partial
+    for p in products:
+        if p.get('brand_name','').strip().lower() == brand_l and name_l in p.get('name','').strip().lower():
+            return p
+    for p in products:
+        if brand_l in p.get('brand_name','').strip().lower() or name_l in p.get('name','').strip().lower():
+            return p
+    raise ValueError('제품을 찾을 수 없습니다: %s / %s' % (brand, product_name))
+
+
+# Ensure src directory is importable when running script directly
+sys.path.insert(0, os.path.dirname(__file__))
+from rag_utils import vectorize_texts, cosine, is_positive_review, extract_candidate_texts, extract_highlight_snippet, build_persona_query
+
+
+def get_device():
+    """Get appropriate device for model inference."""
+    # MPS는 생성 작업에서 문제가 있을 수 있으므로 CUDA만 사용하고 나머지는 CPU 사용
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+class LocalQwenGenerator:
+    """로컬 Qwen 모델을 사용하여 마케팅 초안을 생성합니다."""
+    
+    def __init__(self, model_name="Qwen/Qwen2.5-1.5B-Instruct"):
+        self.device = get_device()
+        self.model_name = model_name
+        print(f"[로컬 Qwen] 디바이스: {self.device}")
+        print(f"[로컬 Qwen] 모델 로딩 중: {model_name}...")
+        
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name,
+            trust_remote_code=True
+        )
+        
+        dtype = torch.float16 if self.device == "cuda" else torch.float32
+        kwargs = {"trust_remote_code": True, "torch_dtype": dtype}
+        if self.device == "cuda":
+            kwargs["device_map"] = "auto"
+        
+        self.model = AutoModelForCausalLM.from_pretrained(model_name, **kwargs)
+        try:
+            self.model.eval()
+        except Exception:
+            pass
+        print("[로컬 Qwen] 모델 로딩 완료")
+    
+    def generate_text(self, messages, max_tokens=512, temperature=0.1):
+        """Generate text using the local model."""
+        try:
+            input_text = self.tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True
+            )
+        except Exception:
+            input_text = "\n".join([f"{m['role']}: {m['content']}" for m in messages])
+        
+        t_start = time.time()
+        
+        inputs = self.tokenizer(
+            input_text,
+            return_tensors="pt",
+            truncation=True,
+            max_length=2048
+        ).to(self.device)
+        
+        try:
+            with torch.inference_mode():
+                output_ids = self.model.generate(
+                    **inputs,
+                    max_new_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=0.9,
+                    do_sample=True,
+                    repetition_penalty=1.1,
+                    pad_token_id=self.tokenizer.eos_token_id
+                )
+        except AttributeError:
+            with torch.no_grad():
+                output_ids = self.model.generate(
+                    **inputs,
+                    max_new_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=0.9,
+                    do_sample=True,
+                    repetition_penalty=1.1,
+                    pad_token_id=self.tokenizer.eos_token_id
+                )
+        
+        t_end = time.time()
+        
+        generated_ids = output_ids[0][inputs['input_ids'].shape[1]:]
+        generated_text = self.tokenizer.decode(generated_ids, skip_special_tokens=True)
+        
+        return generated_text.strip(), t_end - t_start
+    
+    def generate_marketing_draft(self, brand_name, product_name, persona, reviews, highlights):
+        """생성: 마케팅 초안 (One-Stage)."""
+        persona_traits = ", ".join(persona.get("traits", []) if isinstance(persona.get("traits"), list) else [])
+        review_text = "\n".join([f"- {r.get('text', '')[:150]}" for r in reviews[:3]])
+        highlights_text = "\n".join([f"- {h}" for h in highlights[:3]])
+        
+        prompt = f"""당신은 마케팅 카피라이터입니다. 아래 정보를 바탕으로 마케팅 초안을 작성하세요.
+
+[제품]
+브랜드: {brand_name}
+제품명: {product_name}
+
+[타겟 페르소나]
+특성: {persona_traits}
+주요 관심사: {persona.get('value_focus', '제품 품질')}
+
+[고객 리뷰 요약]
+{review_text}
+
+[핵심 포인트]
+{highlights_text}
+
+작성 규칙:
+1. 반드시 다음 형식을 따르세요:
+
+[제목]
+(간결하고 임팩트 있게, 30~40자)
+
+[본문]
+(페르소나 공감과 제품 효과 중심, 200~300자)
+
+2. 리뷰에서 확인 가능한 사실만 사용하세요.
+3. 숫자, 할인율, 이벤트명은 절대 사용하지 마세요.
+4. 페르소나의 가치관을 반영하되, 페르소나 이름(고객군명)은 절대 직접 언급하지 마세요.
+5. 고객을 "당신", "이 제품을 원하는 분들" 등으로 표현하세요.
+"""
+
+        messages = [
+            {"role": "system", "content": f"{persona.get('name', '고객')} 페르소나를 위한 마케팅 전문가입니다."},
+            {"role": "user", "content": prompt}
+        ]
+        
+        marketing_draft, duration = self.generate_text(messages, max_tokens=512, temperature=0.1)
+        return marketing_draft, duration
+
+
+# Ensure src directory is importable when running script directly
+sys.path.insert(0, os.path.dirname(__file__))
+from rag_utils import vectorize_texts, cosine, extract_candidate_texts, extract_highlight_snippet, build_persona_query
+
+
+def generate_marketing_draft(persona, product, highlights):
+    """템플릿 기반 마케팅 초안 생성"""
+    title = f"{product.get('brand_name','')} {product.get('name','')} — {persona.get('name')}용 추천"
+    intro = f"{persona.get('name')} 페르소나에 맞춘 제안: {persona.get('growth_point','')}."
+    pain = f"페르소나 주요 고민: {persona.get('skin_type','')}. 가치 포인트: {persona.get('value_focus','')}."
+    bullets = []
+    for h in highlights:
+        bullets.append('- ' + h)
+    usage = '간단 사용 팁: 아침/저녁 스킨케어 마지막 단계에서 소량을 펴발라 흡수시켜 주세요.'
+    cta = '지금 바로 만나보세요 — 한정 혜택을 확인하세요.'
+    draft = '\n\n'.join([title, intro, pain, '\n'.join(bullets), usage, cta])
+    return draft
+
+
+
+def sanitize_filename(s):
+    return re.sub(r'[^0-9a-zA-Z_-]', '_', s)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--persona', required=True, help='페르소나 인덱스(0~)또는 이름')
+    parser.add_argument('--brand', required=True, help='브랜드명')
+    parser.add_argument('--product', required=True, help='제품명(부분일치 허용)')
+    parser.add_argument('--top_k', type=int, default=3, help='Top-K 리뷰 수')
+    parser.add_argument('--personas_path', default=None, help='페르소나 JSON 경로(테스트용)')
+    parser.add_argument('--products_path', default=None, help='제품 JSON 경로(테스트용)')
+    parser.add_argument('--use_local_model', action='store_true', help='로컬 Qwen 모델 사용 (마케팅 초안 생성)')
+    parser.add_argument('--model_name', default='Qwen/Qwen2.5-1.5B-Instruct', help='로컬 모델 ID')
+    args = parser.parse_args()
+
+    base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    personas_path = args.personas_path or os.path.join(base, 'data', 'personas.json')
+    products_path = args.products_path or os.path.join(base, 'data', 'products.json')
+    personas = load_json(personas_path)
+    products = load_json(products_path)
+
+    persona = find_persona(personas, args.persona)
+    product = find_product(products, args.brand, args.product)
+
+    query = build_persona_query(persona)
+    candidates = extract_candidate_texts(product)
+    all_texts = [query] + candidates
+    vectors = vectorize_texts(all_texts)
+    q_vec = vectors[0]
+    cand_vecs = vectors[1:]
+
+    scores = [(cosine(q_vec, v), i, candidates[i]) for i,v in enumerate(cand_vecs)]
+    scores.sort(reverse=True, key=lambda x: x[0])
+    top = scores[:args.top_k]
+
+    top_k_list = []
+    highlights = []
+    for score, idx, text in top:
+        snippet = extract_highlight_snippet(text)
+        top_k_list.append({'index': idx, 'score': float(score), 'text': text, 'snippet': snippet})
+        highlights.append(snippet)
+
+    draft = generate_marketing_draft(persona, product, highlights)
+
+    product_basic = {
+        'product_id': product.get('product_id'),
+        'name': product.get('name'),
+        'brand_name': product.get('brand_name'),
+        'price': product.get('price'),
+        'url': product.get('url')
+    }
+
+    llm_raw = None
+    llm_parsed = None
+    llm_error = None
+    generation_time = None
+
+    if args.use_local_model:
+        try:
+            print("\n[로컬 Qwen 모델 - 마케팅 초안 생성]")
+            generator = LocalQwenGenerator(model_name=args.model_name)
+            
+            # Generate marketing draft
+            print("[생성] 마케팅 초안을 생성 중...")
+            llm_raw, generation_time = generator.generate_marketing_draft(
+                product.get('brand_name', ''),
+                product.get('name', ''),
+                persona,
+                product.get('reviews', []),
+                highlights
+            )
+            print(f"[완료] ({generation_time:.2f}초)\n")
+            
+            llm_parsed = {
+                'marketing_draft': llm_raw,
+                'generation_time': generation_time
+            }
+        except Exception as e:
+            llm_error = str(e)
+            print(f"[오류] {llm_error}\n")
+
+    out = {
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+        'persona_input': args.persona,
+        'brand': args.brand,
+        'product_query': args.product,
+        'persona_profile': persona,
+        'product_basic': product_basic,
+        'top_k': top_k_list,
+        'marketing_draft': draft
+    }
+    if llm_parsed is not None:
+        out['marketing_draft_llm'] = llm_parsed
+    if llm_raw is not None:
+        out['llm_raw'] = llm_raw
+    if llm_error is not None:
+        out['llm_error'] = llm_error
+    if generation_time is not None:
+        out['generation_time_seconds'] = generation_time
+
+    out_dir = os.path.join(base, 'outputs')
+    os.makedirs(out_dir, exist_ok=True)
+    fname = f"marketing_{sanitize_filename(product.get('brand_name',''))}_{sanitize_filename(product.get('product_id',''))}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    out_path = os.path.join(out_dir, fname)
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+
+    print('✓ 저장 완료:', out_path)
+    print('Top-K snippets:')
+    for i,t in enumerate(top_k_list,1):
+        print(f"  {i}. score: {round(t['score'],3)} | {t['snippet'][:100]}")
+    
+    if llm_raw:
+        print('\n[LLM 생성 마케팅 초안]')
+        print(llm_raw[:400])
+
+
+if __name__ == '__main__':
+    main()

--- a/src/rag_utils.py
+++ b/src/rag_utils.py
@@ -1,0 +1,120 @@
+import re
+import math
+from collections import Counter
+import torch
+from sentence_transformers import SentenceTransformer, util
+
+# 전역 임베딩 모델 (한 번만 로드)
+_embedder = None
+
+def get_embedder():
+    global _embedder
+    if _embedder is None:
+        print("Loading SentenceTransformer model (jhgan/ko-sroberta-multitask)...")
+        _embedder = SentenceTransformer('jhgan/ko-sroberta-multitask')
+    return _embedder
+
+
+def tokenize(text):
+    if not text:
+        return []
+    text = text.lower()
+    text = re.sub(r"[^\w가-힣]+", ' ', text)
+    toks = [t for t in text.split() if len(t) > 1]
+    return toks
+
+
+def vectorize_texts(texts):
+    """SentenceTransformer를 사용한 의미 기반 벡터화"""
+    if not texts:
+        return []
+    embedder = get_embedder()
+    # 벡터를 numpy 배열로 반환 (cosine 함수에서 사용)
+    vectors = embedder.encode(texts, convert_to_tensor=False)
+    return vectors
+
+
+def cosine(a, b):
+    """SentenceTransformer 벡터를 위한 코사인 유사도"""
+    if a is None or b is None:
+        return 0.0
+    import numpy as np
+    a = np.array(a)
+    b = np.array(b)
+    norm_a = np.linalg.norm(a)
+    norm_b = np.linalg.norm(b)
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return float(np.dot(a, b) / (norm_a * norm_b))
+
+
+POSITIVE_KEYWORDS = [
+    '좋', '만족', '추천', '재구매', '인생템', '효과', '흡수', '보습', '탄력', '광채', '진정', '재구매', '신뢰', '가볍', '리뉴얼'
+]
+
+HIGHLIGHT_KEYS = ['효과', '성분', '제형', '흡수', '보습', '재구매', '신뢰', '사용감', '탄력', '주름', '진정', '광채']
+
+
+def is_positive_review(review):
+    if not isinstance(review, dict):
+        return False
+    rating = review.get('rating')
+    if rating:
+        try:
+            if int(rating) >= 4:
+                return True
+        except Exception:
+            pass
+    text = review.get('text','')
+    for k in POSITIVE_KEYWORDS:
+        if k in text:
+            return True
+    return False
+
+
+def extract_candidate_texts(product):
+    """제품의 긍정적인 리뷰 텍스트만 추출 (제품명, 카테고리 제외)"""
+    texts = []
+    
+    # 긍정 리뷰 추출
+    for r in product.get('reviews', []):
+        if is_positive_review(r):
+            text = r.get('text', '').strip()
+            # 최소 길이 필터 (20자 이상만 포함)
+            if len(text) > 20:
+                texts.append(text)
+    
+    # 긍정 리뷰가 부족하면 모든 리뷰 추가
+    if len(texts) < 3:
+        for r in product.get('reviews', []):
+            text = r.get('text', '').strip()
+            if len(text) > 20 and text not in texts:
+                texts.append(text)
+    
+    return texts
+
+
+def extract_highlight_snippet(text):
+    if not text:
+        return ''
+    sents = re.split(r'[\.\n]+', text)
+    for s in sents:
+        for k in HIGHLIGHT_KEYS:
+            if k in s:
+                return s.strip()
+    t = text.strip()
+    return (t[:200] + '...') if len(t) > 200 else t
+
+
+def build_persona_query(persona):
+    parts = []
+    if persona.get('skin_type'):
+        parts.append('주요 고민: ' + persona['skin_type'])
+    if persona.get('value_focus'):
+        parts.append('가치관: ' + persona['value_focus'])
+    if persona.get('shopping_style'):
+        parts.append('쇼핑스타일: ' + persona['shopping_style'])
+    if persona.get('growth_point'):
+        parts.append('성장 포인트: ' + persona['growth_point'])
+    query = ' | '.join(parts)
+    return query


### PR DESCRIPTION
## QWEN 파이프라인 

### Step 1: 데이터 로드
- data/personas.json 로드
- data/products.json 로드
- --persona 인덱스를 사용해 페르소나 객체 선택
- --brand, --product 값을 기준으로 제품 객체 탐색

↓

### Step 2: RAG (유사도 기반 리뷰 추출)
1. 페르소나 특징을 기반으로 쿼리 생성 (build_persona_query)
- skin_type, value_focus, shopping_style 등을 조합
2. 제품 리뷰 텍스트 수집 (extract_candidate_texts)
- 제품명, 카테고리 기준
- 긍정 리뷰(평점 4점 이상 또는 특정 키워드 포함)
3. SentenceTransformer를 사용한 임베딩 생성
- 이 단계에서 주요 연산 시간 소요
4. 코사인 유사도 계산 (cosine)
- 페르소나 쿼리 벡터와 리뷰 벡터 간 유사도 계산
- 상위 K개 리뷰 선택 (기본값: 3)
5. 하이라이트 문장 추출 (extract_highlight_snippet)
- 각 리뷰에서 핵심 키워드가 포함된 문장 추출
- 키워드 예: 효과, 성분, 제형, 흡수, 보습, 재구매 등

↓

### Step 3: 템플릿 기반 초안 생성
- generate_marketing_draft() 함수 사용
- 제목: {브랜드} {제품} — {페르소나명}용 추천
- 본문: 페르소나 고민 + 리뷰 스니펫 + 사용 팁 + CTA
- 결과를 out['marketing_draft']에 저장

↓

### Step 4: LLM 기반 마케팅 초안 생성 (--use_local_model)
- --use_local_model 플래그가 활성화된 경우에만 수행
1. LocalQwenGenerator 초기화
- Qwen/Qwen2.5-1.5B-Instruct 모델 다운로드
- CPU 또는 CUDA 디바이스 설정
- 모델 가중치 로드 (약 3GB)
2. generate_marketing_draft() 호출
- 입력: 페르소나 정보, 제품명, 리뷰 하이라이트
- 프롬프트 생성
- 모델 추론을 통한 토큰 생성
- 출력 형식: [제목] ... [본문] ...
3. 결과 저장
- llm_raw: LLM이 생성한 원본 텍스트
- llm_parsed: { marketing_draft, generation_time }
- generation_time: 생성 소요 시간(초)

### 결과물 
<img width="717" height="322" alt="image" src="https://github.com/user-attachments/assets/236f83b2-b193-402c-aaaf-62377f457671" />
